### PR TITLE
T1 31  search page

### DIFF
--- a/src/components/addepigram/AddEpigramPageInput.tsx
+++ b/src/components/addepigram/AddEpigramPageInput.tsx
@@ -148,6 +148,7 @@ const AddEpigramPageInput: React.FC = () => {
                     <input
                       type="radio"
                       name="라디오버튼"
+                      checked={!(author === '알 수 없음' || author === '본인')}
                       onClick={() => setAuthor('')}
                       className="h-[20px] w-[20px] rounded-[10px] border-2 border-blue-300 align-middle xl:h-[24px] xl:w-[24px] xl:rounded-[40px]"
                       color="black"

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -57,7 +57,11 @@ const Header: React.FC = () => {
   };
 
   const handleLogoClick = (): void => {
-    router.push('/');
+    if (isLoggedIn) {
+      router.push('/epigrams');
+    } else {
+      router.push('/');
+    }
   };
 
   const handleProfileClick = (): void => {

--- a/src/components/search/RecentSearches.tsx
+++ b/src/components/search/RecentSearches.tsx
@@ -5,6 +5,7 @@ interface RecentSearchesProps {
   onClearAll: () => void;
   onClickItem: (term: string) => void;
   onRemoveItem: (term: string) => void;
+  isRecentSearches: boolean | undefined;
 }
 
 const RecentSearches: React.FC<RecentSearchesProps> = ({
@@ -12,6 +13,7 @@ const RecentSearches: React.FC<RecentSearchesProps> = ({
   onClearAll,
   onClickItem,
   onRemoveItem,
+  isRecentSearches,
 }) => {
   return (
     <div>
@@ -19,12 +21,14 @@ const RecentSearches: React.FC<RecentSearchesProps> = ({
         <p className="text-xl font-medium text-black-700 md:text-2xl xl:text-[24px]">
           최근 검색어
         </p>
-        <button
-          onClick={onClearAll}
-          className="text-sm font-semibold text-red-500 md:text-lg xl:text-xl"
-        >
-          모두 지우기
-        </button>
+        {isRecentSearches && (
+          <button
+            onClick={onClearAll}
+            className="text-sm font-semibold text-red-500 md:text-lg xl:text-xl"
+          >
+            모두 지우기
+          </button>
+        )}
       </div>
       <div className="mb-[24px] mt-4 flex flex-wrap gap-2 md:mb-[32px] md:mt-[24px] md:gap-4 xl:my-[40px]">
         {recentSearches.map((term, index) => (


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
### 헤더 로고
클릭시 로그인 된상태에서는 에피그램 /epigrams 페이지로 가게 했습니다. 기능구현중 하나였습니다.

### 검색페이지
모두지우기 버튼, 최근검색어가 없으면 안보이게 했습니다.

### 에피그램작성 
기본 ratio 주었습니다. 멘토님이 얘기해주신부분

### 스크린샷 (선택)
<img width="958" alt="스크린샷 2024-08-28 오후 7 06 07" src="https://github.com/user-attachments/assets/f70e73c5-e526-4148-90fb-11e26ed636f2">
<img width="958" alt="스크린샷 2024-08-28 오후 7 06 00" src="https://github.com/user-attachments/assets/0145b52d-371a-4bb0-99f8-f3c3a9e7306d">
<img width="958" alt="스크린샷 2024-08-28 오후 7 05 55" src="https://github.com/user-attachments/assets/44af60c8-2490-486e-ab75-0089f9e85f01">


## 💬리뷰 요구사항(선택) 
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
