### PR TITLE
베포 - 상세페이지 글자 잘리는 부분 수정했습니다

### DIFF
--- a/src/app/epigrams/[id]/page.tsx
+++ b/src/app/epigrams/[id]/page.tsx
@@ -26,7 +26,7 @@ const DetailPage = () => {
 
   return (
     <div>
-      <div className="h-[300px] bg-striped md:h-[366px] xl:h-[400px]">
+      <div className="h-auto bg-striped">
         <div className="mx-auto w-[312px] pt-10 md:w-[384px] xl:w-[640px]">
           <EpigramDetails epigram={data} />
         </div>

--- a/src/components/detailPage/EpigramDetails.tsx
+++ b/src/components/detailPage/EpigramDetails.tsx
@@ -147,14 +147,14 @@ const EpigramDetails: React.FC<EpigramProps> = ({ epigram }) => {
             </div>
           )}
         </div>
-        <div className="font-custom text-[24px] leading-[40px] xl:text-[32px] xl:leading-[48px]">
+        <div className="whitespace-pre-wrap font-custom text-[24px] leading-[40px] xl:text-[32px] xl:leading-[48px]">
           {epigram.content}
         </div>
         <div className="text-right font-custom text-[16px] leading-[26px] text-[#ABB8CE] md:text-[20px] md:leading-[28px] xl:text-[24px] xl:leading-[20px]">
           - {epigram.author} -
         </div>
       </div>
-      <div className="absolute left-1/2 top-[300px] flex -translate-x-1/2 transform items-center gap-4 md:top-[365px] xl:top-[400px]">
+      <div className="mb-[16px] mt-[32px] flex items-center justify-center gap-4 md:top-[365px] md:my-[32px] xl:top-[40px] xl:mb-[40px] xl:mt-[36px]">
         <button
           onClick={handleLikeToggle}
           className="flex items-center gap-1 rounded-full bg-black-600 px-[14px] py-[6px] text-white"


### PR DESCRIPTION
수정 전
![image](https://github.com/user-attachments/assets/43f557a0-dcc4-487d-add3-f4b2b49affbd)




수정 후
![image](https://github.com/user-attachments/assets/754241c0-6a09-463b-902d-b18384259ba2)
